### PR TITLE
Removed role cache from Permission Service.

### DIFF
--- a/src/main/java/org/ohdsi/webapi/security/model/UserSimpleAuthorizationInfo.java
+++ b/src/main/java/org/ohdsi/webapi/security/model/UserSimpleAuthorizationInfo.java
@@ -1,25 +1,39 @@
 package org.ohdsi.webapi.security.model;
 
+import java.util.List;
+import java.util.Map;
+import org.apache.shiro.authz.Permission;
 import org.apache.shiro.authz.SimpleAuthorizationInfo;
 
 public class UserSimpleAuthorizationInfo extends SimpleAuthorizationInfo {
-    private Long userId;
 
-    private String login;
+  private Long userId;
+  private String login;
+  private Map<String,List<Permission>> permissionIdx;
 
-    public Long getUserId() {
-        return userId;
-    }
+  
+  public Long getUserId() {
+    return userId;
+  }
 
-    public void setUserId(Long userId) {
-        this.userId = userId;
-    }
+  public void setUserId(Long userId) {
+    this.userId = userId;
+  }
 
-    public String getLogin() {
-        return login;
-    }
+  public String getLogin() {
+    return login;
+  }
 
-    public void setLogin(String login) {
-        this.login = login;
-    }
+  public void setLogin(String login) {
+    this.login = login;
+  }
+  
+  public Map<String, List<Permission>> getPermissionIdx() {
+    return permissionIdx;
+  }
+
+  public void setPermissionIdx(Map<String, List<Permission>> permissionIdx) {
+    this.permissionIdx = permissionIdx;
+  }
+
 }

--- a/src/main/java/org/ohdsi/webapi/service/UserService.java
+++ b/src/main/java/org/ohdsi/webapi/service/UserService.java
@@ -51,7 +51,7 @@ public class UserService {
     public String login;
     public String name;
     public List<Permission> permissions;
-    public JsonNode permissionIdx;
+    public Map<String, List<String>> permissionIdx;
 
     public User() {}
 

--- a/src/main/java/org/ohdsi/webapi/shiro/filters/CacheFilter.java
+++ b/src/main/java/org/ohdsi/webapi/shiro/filters/CacheFilter.java
@@ -19,9 +19,6 @@ public class CacheFilter implements Filter {
     @Autowired
     private PermissionManager permissionManager;
 
-    @Autowired
-    private PermissionService permissionService;
-
     @Override
     public void init(FilterConfig filterConfig) throws ServletException {
 
@@ -31,7 +28,6 @@ public class CacheFilter implements Filter {
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
 
         permissionManager.clearAuthorizationInfoCache();
-        permissionService.clearPermissionCache();
         chain.doFilter(request, response);
     }
 

--- a/src/main/java/org/ohdsi/webapi/shiro/realms/JwtAuthRealm.java
+++ b/src/main/java/org/ohdsi/webapi/shiro/realms/JwtAuthRealm.java
@@ -1,12 +1,17 @@
 package org.ohdsi.webapi.shiro.realms;
 
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.shiro.authc.AuthenticationException;
 import org.apache.shiro.authc.AuthenticationInfo;
 import org.apache.shiro.authc.AuthenticationToken;
 import org.apache.shiro.authc.SimpleAuthenticationInfo;
 import org.apache.shiro.authz.AuthorizationInfo;
+import org.apache.shiro.authz.Permission;
 import org.apache.shiro.realm.AuthorizingRealm;
 import org.apache.shiro.subject.PrincipalCollection;
+import org.ohdsi.webapi.security.model.UserSimpleAuthorizationInfo;
 import org.ohdsi.webapi.shiro.PermissionManager;
 import org.ohdsi.webapi.shiro.tokens.JwtAuthToken;
 
@@ -37,5 +42,20 @@ public class JwtAuthRealm extends AuthorizingRealm {
   @Override
   protected AuthenticationInfo doGetAuthenticationInfo(AuthenticationToken at) throws AuthenticationException {
     return new SimpleAuthenticationInfo(at.getPrincipal(), "", getName());
-  }  
+  }
+
+  @Override
+  protected boolean isPermitted(Permission permission, AuthorizationInfo info) {
+    // for speed, we check the permission against the set of permissions found by the key '*' and the first element of the permission.
+    String permPrefix =  StringUtils.split(permission.toString(), ":")[0];
+    // we only need to check * perms and perms that begin with the same prefix (up to first :) as the requested permission
+    // starting with perms that start with *
+    List<Permission> permsToCheck = new ArrayList(((UserSimpleAuthorizationInfo)info).getPermissionIdx().getOrDefault("*", new ArrayList<>()));
+    // adding those permissiosn that start with the permPrefix
+    permsToCheck.addAll(((UserSimpleAuthorizationInfo)info).getPermissionIdx().getOrDefault(permPrefix, new ArrayList<>()));
+    
+    // do check
+    return permsToCheck.stream().anyMatch(permToCheck -> permToCheck.implies(permission));
+    
+  }
 }


### PR DESCRIPTION
Changed read/write permission checks to use permissions instead of roles. Permission checks are using Subject.isPermitted() which honors wildcard semantics. Altered JwtAuthRealm to filter user permissions to either * or first element of permission to check for speed. Changed permission index from JsonNode to Map<>.  Serializes same way, but map semantics are simpler to navigate. Altered AuthrizationInfo to contain index of Permissions and store Wildcard perms.

General cleanup of unused imports and removed unused dependencies (ie: Autowired fields were removed if no longer needed).

Fixes #2353.