### PR TITLE
Fix: add missing read permissions to PermissionSchema classes

### DIFF
--- a/src/main/java/org/ohdsi/webapi/security/model/CohortDefinitionPermissionSchema.java
+++ b/src/main/java/org/ohdsi/webapi/security/model/CohortDefinitionPermissionSchema.java
@@ -14,14 +14,14 @@ public class CohortDefinitionPermissionSchema extends EntityPermissionSchema {
         put("cohortdefinition:%s:check:post", "Fix Cohort Definition with ID = %s");
     }};
 
-  private static Map<String, String> readPermissions = new HashMap<String, String>() {{                                     
-	put("cohortdefinition:%s:get", "Get Cohort Definition by ID");
-	put("cohortdefinition:%s:info:get","");
+    private static Map<String, String> readPermissions = new HashMap<String, String>() {{                                     
+        put("cohortdefinition:%s:get", "Get Cohort Definition by ID");
+        put("cohortdefinition:%s:info:get","");
 
-	put("cohortdefinition:%s:version:get", "Get list of cohort versions");
-	put("cohortdefinition:%s:version:*:get", "Get cohort version");		       
-      }
-    };
+        put("cohortdefinition:%s:version:get", "Get list of cohort versions");
+        put("cohortdefinition:%s:version:*:get", "Get cohort version");		       
+        put("cohortdefinition:%s:copy:get", "Copy the specified cohort definition");
+    }};
   
     public CohortDefinitionPermissionSchema() {
 

--- a/src/main/java/org/ohdsi/webapi/security/model/ConceptSetPermissionSchema.java
+++ b/src/main/java/org/ohdsi/webapi/security/model/ConceptSetPermissionSchema.java
@@ -18,6 +18,9 @@ public class ConceptSetPermissionSchema extends EntityPermissionSchema {
         put("conceptset:%s:get", "view conceptset  definition with id %s");
         put("conceptset:%s:expression:get", "Resolve concept set %s expression");
         put("conceptset:%s:version:*:expression:get", "Get expression for concept set %s items for default source");
+        put("conceptset:%s:expression:*:get", "expression:*:get permission, specific to this conceptset with id %s");
+        put("conceptset:%s:version:get", "version:get permission, specific to this conceptset with id %s");
+        put("conceptset:%s:copy-name:get", "copy-name:get permission, specific to this conceptset with id %s");
     }};
 
     public ConceptSetPermissionSchema() {


### PR DESCRIPTION
Fix: add missing read permissions to PermissionSchema classes. This is needed since the removal of the respective * permissions from role 15 in https://github.com/vinci-ohdsi/WebAPI-2-15-dev/pull/7